### PR TITLE
Fix the system requirements link for 128.0esr.

### DIFF
--- a/release/128.0esr.yml
+++ b/release/128.0esr.yml
@@ -8,7 +8,7 @@ release:
     **For more on all the new features in Thunderbird 128, see
     [What’s New in Thunderbird 128](https://www.thunderbird.net/thunderbird/128.0/whatsnew/).**
 
-    **System Requirements:** [Details](/en-US/thunderbird/128.0/system-requirements/)
+    **System Requirements:** [Details](/en-US/thunderbird/128.0esr/system-requirements/)
 
   system_requirements: |
     ## Windows


### PR DESCRIPTION
I've setup a redirect so https://www.thunderbird.net/thunderbird/128.0esr/whatsnew/ goes to https://www.thunderbird.net/thunderbird/128.0/whatsnew/ (which is the canonical link for the whatsnew page.) I don't know if we want to adjust that as well.

But this should fix the broken system requirements link on the release notes. Which will now point to https://stage.thunderbird.net/en-US/thunderbird/128.0esr/system-requirements/ (and https://www.thunderbird.net/en-US/thunderbird/128.0esr/system-requirements/ although this isn't on prod yet.)

Please merge this if the changes are okay! 